### PR TITLE
Add resultant binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@
 # Secrets directory for development
 secrets/
 
-vendor
+vendorterm-check

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@
 # Secrets directory for development
 secrets/
 
-vendorterm-check
+vendor
+term-check


### PR DESCRIPTION
The output of `make` shouldn't be part checked in to the repository.
rm it from the repo and add it to the ignored file list