### PR TITLE
Migrate imports to using zendesk org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.11-alpine AS build_base
 
 RUN apk add bash ca-certificates git gcc g++ libc-dev
-WORKDIR /go/src/github.com/ragurney/term-check
+WORKDIR /go/src/github.com/zendesk/term-check
 
 ENV GO111MODULE=on
 
@@ -22,6 +22,6 @@ FROM alpine AS term-check
 RUN apk add ca-certificates
 
 COPY --from=server_builder /go/bin/term-check /bin/term-check
-COPY --from=server_builder /go/src/github.com/ragurney/term-check/config.yaml .
+COPY --from=server_builder /go/src/github.com/zendesk/term-check/config.yaml .
 
 ENTRYPOINT ["/bin/term-check", "--config", "config.yaml"]

--- a/cmd/term-check/main.go
+++ b/cmd/term-check/main.go
@@ -6,8 +6,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/ragurney/term-check/internal/bot"
-	"github.com/ragurney/term-check/internal/config"
+	"github.com/zendesk/term-check/internal/bot"
+	"github.com/zendesk/term-check/internal/config"
 )
 
 var filepath = flag.String("config", "config.yaml", "Location of the configuration file.")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ragurney/term-check
+module github.com/zendesk/term-check
 
 require (
 	github.com/bradleyfalzon/ghinstallation v0.1.2

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/google/go-github/v18/github"
-	"github.com/ragurney/term-check/internal/config"
-	gh "github.com/ragurney/term-check/pkg/github"
-	"github.com/ragurney/term-check/pkg/lib"
+	"github.com/zendesk/term-check/internal/config"
+	gh "github.com/zendesk/term-check/pkg/github"
+	"github.com/zendesk/term-check/pkg/lib"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/waigani/diffparser"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 
-	"github.com/ragurney/term-check/pkg/config"
+	"github.com/zendesk/term-check/pkg/config"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )


### PR DESCRIPTION
Instead of importing `github.com/ragurney/term-check`, use `github.com/zendesk/term-check`