### PR TITLE
Change Details Text

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ botConfig:
   checkName: Inclusive Language Check
   checkSuccessSummary: Looks good! 😇
   checkFailureSummary: 👋 exclusive language
-  checkDetails: Found exclusive language
+  checkDetails: "Language check results:"
   annotationTitle: Exclusive Language
   annotationBody: |
     Hi there! 👋 I see you used the term(s) [%s] here. This language is exclusionary for members of our community,


### PR DESCRIPTION
It looks like the details section always appears regardless of annotations created or not. We should perhaps add programatic details text in the future (e.g. a `SuccessDetails` and `FailedDetails` option), but for now this will avoid any unnecessary confusion. 