### PR TITLE
Remove 'master' from term list

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,6 @@ shared:
 botConfig:
   appID: *appID
   termList:
-    - master
     - slave
   checkName: Inclusive Language Check
   checkSuccessSummary: Looks good! 😇


### PR DESCRIPTION
This was coming up a lot in reference to the 'master' branch. Removing now and keeping 'slave'