### PR TITLE
Repo-specific settings and `ignore` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,56 @@
 
 This bot is for our Inclusive Language initiative inside Zendesk Engineering.
 
+## Configuration
+
+### Bot Configuration
+
+Configuration for the bot's behavior is contained in `config.yaml`, e.x.
+
+```yaml
+# Any shared configuration between fields
+shared:
+  # ID of the GitHub application
+  appID: &appID 123456
+botConfig:
+  appID: *appID
+  # List of terms to look for and flag in code
+  termList:
+    - slave
+  # Name of the check. Will appear in the status list and as the title on the 'details' page
+  checkName: Inclusive Language Check
+  # Check summary to set when no terms are found
+  checkSuccessSummary: Looks good! 😇
+  # Check summary to set when terms are found
+  checkFailureSummary: 👋 exclusive language
+  # Generic check details text
+  checkDetails: "Language check results:"
+  # Text for the title of check annotations created for each flagged term in the code
+  annotationTitle: Exclusive Language
+  # Text for the body of each annotation. Supports one format string [%s] which will be replaced by the flagged terms
+  # found on that line
+  annotationBody: |
+    Hi there! 👋 I see you used the term(s) [%s] here. This language is exclusionary for members of our community,
+    please consider changing it.
+clientConfig:
+  appID: *appID
+  # Path to the private key generated for the GitHub application
+  privateKeyPath: /secrets/PRIVATE_KEY
+```
+
+### Repo-specific Configuration
+
+Certain behaviors are configurable on a per repository basis. Add a `.github/inclusive_lang.yaml` file to your
+repository based off of the following template:
+
+```yaml
+# An array of patterns following .gitignore rules (http://git-scm.com/docs/gitignore) specifying which files and
+# directories should be ignored by the app
+ignore:
+  - foo
+  - bar/
+```
+
 ## Copyright and license
 
 Copyright 2019 Zendesk, Inc.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/juju/version v0.0.0-20180108022336-b64dbd566305 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/rs/zerolog v1.10.0
+	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
 	github.com/stretchr/testify v1.3.0
 	github.com/waigani/diffparser v0.0.0-20180518143736-8ef6bf958d9e
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/zerolog v1.10.0 h1:roFDW4AgYGbHnTOAMZ2K8mHJZ/7bSj7txPfvbABIj88=
 github.com/rs/zerolog v1.10.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -12,12 +12,13 @@ import (
 	"time"
 
 	"github.com/google/go-github/v18/github"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/sabhiram/go-gitignore"
+	"github.com/waigani/diffparser"
 	"github.com/zendesk/term-check/internal/config"
 	gh "github.com/zendesk/term-check/pkg/github"
 	"github.com/zendesk/term-check/pkg/lib"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/waigani/diffparser"
 )
 
 const (
@@ -201,6 +202,11 @@ func (b *Bot) createCheckRun(ctx context.Context, pr *github.PullRequest, r *git
 
 func (b *Bot) createAnnotations(ctx context.Context, pr *github.PullRequest, r *github.Repository, ghc *github.Client) ([]*github.CheckRunAnnotation, error) {
 	headSHA := pr.GetHead().GetSHA()
+
+	// Get repository configuration
+	ic := config.GetRepoConfig(ctx, r, headSHA, ghc)
+
+	// Get PR diff
 	diff, resp, err := ghc.PullRequests.GetRaw( // TODO: refactor to move methods making requests to Client?
 		ctx,
 		r.GetOwner().GetLogin(),
@@ -212,7 +218,6 @@ func (b *Bot) createAnnotations(ctx context.Context, pr *github.PullRequest, r *
 		e := fmt.Errorf("Failed to get diff for %s: %s", headSHA, err)
 		return []*github.CheckRunAnnotation{}, e
 	}
-
 	parsedDiff, err := diffparser.Parse(diff)
 	if err != nil {
 		e := fmt.Errorf("Failed to parse diff for %s: %s", headSHA, err)
@@ -223,6 +228,19 @@ func (b *Bot) createAnnotations(ctx context.Context, pr *github.PullRequest, r *
 	var annotations = []*github.CheckRunAnnotation{}
 
 	for _, f := range parsedDiff.Files {
+		// Skip over any files listed in `ignore`
+		if ignorePatterns := ic.Ignore; ignorePatterns != nil {
+			ignoreMatcher, err := ignore.CompileIgnoreLines(ignorePatterns...)
+
+			if err != nil {
+				log.Warn().Err(err).Msg("Disregarding `ignore` configuration")
+			} else {
+				if ignoreMatcher.MatchesPath(f.NewName) {
+					continue
+				}
+			}
+		}
+
 		for _, h := range f.Hunks {
 			adds := h.NewRange
 			for _, l := range adds.Lines {


### PR DESCRIPTION
This adds support to have repository-specific settings, and introduces the `ignore` setting which would allow users to specify files or directories that should not be scanned by the bot.

Resolves #16 