### PR TITLE
Set log level to error as default

### DIFF
--- a/cmd/term-check/main.go
+++ b/cmd/term-check/main.go
@@ -3,6 +3,8 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -11,10 +13,18 @@ import (
 )
 
 var filepath = flag.String("config", "config.yaml", "Location of the configuration file.")
+var debug = flag.Bool("debug", os.Getenv("LOG_LEVEL") == "debug", "sets log level to debug")
 
 func main() {
 	zerolog.TimeFieldFormat = ""
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
 	flag.Parse()
+
+	// Default logging level is info unless debug flag is present
+	if *debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
 
 	c := config.New(*filepath)
 


### PR DESCRIPTION
Use -debug flag to turn on debug logs. This is the example way to do this for the github.com/rs/zerolog package, but seems like it would be much nicer to do this via an environment variable?