### PR TITLE
Add complementary terms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,8 +4,9 @@ botConfig:
   appID: *appID
   termList:
     - blacklist
-    - slave
     - whitelist
+    - slave
+    - master
   checkName: Inclusive Language Check
   checkSuccessSummary: Looks good! 😇
   checkFailureSummary: 👋 exclusive language


### PR DESCRIPTION
If slave is not allowed, then master shouldn't be allowed either,

or we can run into the case where I start freely using the term master
but later on I find out I can't match it with slave, which could incur
in inconsistencies or expensive refactorings.