### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS file
+# This file defines who should review code changes in this repository.
+
+* @zendesk/bots


### PR DESCRIPTION
This PR adds a CODEOWNERS file to ensure proper code review coverage.

According to Zendesk standards, all public repositories should have CODEOWNERS files:
The CODEOWNERS file specifies who should review code changes in this repository.